### PR TITLE
[fix]Support custom chunks which might have no parent.

### DIFF
--- a/src/lib/does-chunk-belong-to-html.js
+++ b/src/lib/does-chunk-belong-to-html.js
@@ -47,6 +47,7 @@ function recursiveChunkEntryName (chunk) {
 }
 
 function _recursiveChunkGroup (chunkGroup) {
+  if (!chunkGroup) return undefined;
   if (chunkGroup instanceof EntryPoint) {
     return chunkGroup.name
   } else {


### PR DESCRIPTION
Some other plugins might create custom chunks which might have no parent.(getParents returns empty array)